### PR TITLE
Extend-break-after-4-pomodoros

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -49,6 +49,9 @@ class App extends Component {
         <Timer
           sessionLength={this.state.sessionLength}
           breakLength={this.state.breakLength}
+          setBreakLength={(newLength) =>
+            this.setState({ breakLength: newLength })
+          }
           isTimerRunning={this.state.isTimerRunning}
           setIsTimerRunning={(newIsTimerRunning) =>
             this.setState({ isTimerRunning: newIsTimerRunning })

--- a/src/components/SessionLength.jsx
+++ b/src/components/SessionLength.jsx
@@ -1,19 +1,17 @@
-
 const Session = ({ sessionLength, setSessionLength, isTimerRunning }) => {
-
   const incrementSession = () => {
-     if (sessionLength < 40){
-        if (!isTimerRunning){
-                setSessionLength(sessionLength + 1);
-        }
-     }
+    if (sessionLength < 40) {
+      if (!isTimerRunning) {
+        setSessionLength(sessionLength + 1);
+      }
+    }
   };
 
   const decrementSession = () => {
-    if (sessionLength > 5){
-        if (!isTimerRunning){
-                setSessionLength(sessionLength - 1);
-        }
+    if (sessionLength > 5) {
+      if (!isTimerRunning) {
+        setSessionLength(sessionLength - 1);
+      }
     }
   };
 
@@ -25,10 +23,18 @@ const Session = ({ sessionLength, setSessionLength, isTimerRunning }) => {
       <p className="session-length" id="session-length">
         {sessionLength}
       </p>
-      <button className="session-decrement" id="session-decrement" onClick={decrementSession}>
+      <button
+        className="session-decrement"
+        id="session-decrement"
+        onClick={decrementSession}
+      >
         -
       </button>
-      <button className="session-increment" id="session-increment" onClick={incrementSession}>
+      <button
+        className="session-increment"
+        id="session-increment"
+        onClick={incrementSession}
+      >
         +
       </button>
     </div>

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -6,6 +6,7 @@ class Timer extends React.Component {
     this.state = {
       timeLeft: this.props.sessionLength * 60, // in seconds
       isSession: true, // track whether the timer is in session or break mode
+      pomodorosCompleted: 0,
     };
     this.timer = null;
     this.startStopTimer = this.startStopTimer.bind(this);

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -49,8 +49,13 @@ class Timer extends React.Component {
 
       this.setState({
         timeLeft: this.state.isSession
-          ? this.props.breakLength * 60
+          ? this.pomodorosCompleted % 3 == 0
+            ? this.props.setBreakLength(3 * this.props.breakLength)
+            : this.props.breakLength * 60
           : this.props.sessionLength * 60,
+        pomodorosCompleted: !this.state.isSession
+          ? this.state.pomodorosCompleted + 1 // increase the number of pomodoros completed if the timer was in break mode
+          : this.state.pomodorosCompleted,
         isSession: !this.state.isSession, // switch to break mode if the timer was in session mode, or vice versa
       });
       // restart the timer if the auto switch is enabled


### PR DESCRIPTION
This PR adds a new feature that extends break sessions to be 3 times longer after completing 4 pomodoros. It tracks the number of pomodoros completed and adjusts the break time accordingly. This enhancement enhances productivity by rewarding focused work with longer breaks