### PR TITLE
Freedompraise/issue18

### DIFF
--- a/src/components/BreakLength.jsx
+++ b/src/components/BreakLength.jsx
@@ -56,7 +56,7 @@ class Break extends React.Component {
             data-testid="break-length"
             value={breakLength}
             onChange={this.handleLengthChange}
-            className="rounded-md py-2 px-2 mx-2 w-12 text-center"
+            className="rounded-md py- px-2 mx-0 w-12 text-center"
             style={{ backgroundColor: "transparent" }}
           />
           <button

--- a/src/components/BreakLength.jsx
+++ b/src/components/BreakLength.jsx
@@ -56,7 +56,7 @@ class Break extends React.Component {
             data-testid="break-length"
             value={breakLength}
             onChange={this.handleLengthChange}
-            className="rounded-md py-2 px-4 mx-2 w-10 text-center"
+            className="rounded-md py-2 px-2 mx-2 w-12 text-center"
             style={{ backgroundColor: "transparent" }}
           />
           <button

--- a/src/components/BreakLength.jsx
+++ b/src/components/BreakLength.jsx
@@ -3,6 +3,9 @@ import React from "react";
 class Break extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      inputValue: this.props.breakLength.toString(), // for controlled input
+    };
     this.handleLengthChange = this.handleLengthChange.bind(this);
   }
 
@@ -26,14 +29,23 @@ class Break extends React.Component {
     }
   };
 
+  componentDidUpdate(prevProps) {
+    // Check if the breakLength prop has changed
+    if (prevProps.breakLength !== this.props.breakLength) {
+      // Update inputValue with the new breakLength as a string
+      this.setState({ inputValue: this.props.breakLength.toString() });
+    }
+  }
+
   handleLengthChange = (e) => {
-    const value = e.target.value;
-    if (value >= 5 && value <= 40) {
-      this.setState({ breakLength: value });
-      this.props.setBreakLength(value);
+    const newValue = e.target.value;
+
+    // Only update state if the value is a valid number within the specified range
+    if (!isNaN(newValue) && newValue >= 1 && newValue <= 10) {
+      this.setState({ inputValue: newValue });
+      this.props.setBreakLength(parseInt(newValue, 10));
     }
   };
-
   render() {
     const { breakLength } = this.props;
 
@@ -54,9 +66,9 @@ class Break extends React.Component {
           <input
             id="break-length"
             data-testid="break-length"
-            value={breakLength}
+            value={this.state.inputValue}
             onChange={this.handleLengthChange}
-            className="rounded-md py- px-2 mx-0 w-12 text-center"
+            className="rounded-md py-2 px-2 mx-0 w-12 text-center"
             style={{ backgroundColor: "transparent" }}
           />
           <button

--- a/src/components/SessionLength.jsx
+++ b/src/components/SessionLength.jsx
@@ -53,7 +53,7 @@ class Session extends Component {
             data-testid="session-length"
             value={sessionLength}
             onChange={this.handleLengthChange}
-            className="rounded-md py-2 px-2 mx-2 w-12 text-center"
+            className="rounded-md py-2 px-2 mx-0 w-12 text-center"
             style={{ backgroundColor: "transparent" }}
           />
           <button

--- a/src/components/SessionLength.jsx
+++ b/src/components/SessionLength.jsx
@@ -3,6 +3,9 @@ import React, { Component } from "react";
 class Session extends Component {
   constructor(props) {
     super(props);
+    this.state = {
+      inputValue: this.props.sessionLength.toString(), // for controlled input
+    };
     this.handleLengthChange = this.handleLengthChange.bind(this);
   }
 
@@ -24,13 +27,23 @@ class Session extends Component {
     }
   };
 
+  componentDidUpdate(prevProps) {
+    // Check if the sessionLength prop has changed
+    if (prevProps.sessionLength !== this.props.sessionLength) {
+      // Update inputValue with the new sessionLength as a string
+      this.setState({ inputValue: this.props.sessionLength.toString() });
+    }
+  }
+
   handleLengthChange = (e) => {
-    const value = e.target.value;
-    if (value >= 5 && value <= 40) {
-      this.props.setSessionLength(value);
+    const newValue = e.target.value;
+
+    // Only update state if the value is a valid number within the specified range
+    if (!isNaN(newValue) && newValue >= 5 && newValue <= 40) {
+      this.setState({ inputValue: newValue });
+      this.props.setSessionLength(parseInt(newValue, 10));
     }
   };
-
   render() {
     const { sessionLength } = this.props;
 
@@ -51,7 +64,7 @@ class Session extends Component {
           <input
             id="session-length"
             data-testid="session-length"
-            value={sessionLength}
+            value={this.state.inputValue}
             onChange={this.handleLengthChange}
             className="rounded-md py-2 px-2 mx-0 w-12 text-center"
             style={{ backgroundColor: "transparent" }}

--- a/src/components/SessionLength.jsx
+++ b/src/components/SessionLength.jsx
@@ -53,7 +53,7 @@ class Session extends Component {
             data-testid="session-length"
             value={sessionLength}
             onChange={this.handleLengthChange}
-            className="rounded-md py-2 px-4 mx-2 w-10 text-center"
+            className="rounded-md py-2 px-2 mx-2 w-12 text-center"
             style={{ backgroundColor: "transparent" }}
           />
           <button


### PR DESCRIPTION
**Pull Request Description:**
This pull request addresses the issue described in Issue #18 . It also includes enhancements to improve the functionality of the `Session` and `Break` components.

**Changes Made:**
- Updated the `handleLengthChange` function to handle user input correctly and allow for typing in a new session length value.
- Ensured that the input field visually reflects the current session/break length.
- Updated the input field width for better visual aesthetics.
- Added a `componentDidUpdate` method to sync the input field with the `sessionLength`, and `breakLength` prop.

**Testing:**
I have tested these changes locally to ensure that the input field now allows users to type in a new session length value, and it correctly updates the `sessionLength`, and `breakLength`.

**Outstanding Issues:**
1. Typing in the input field does not always update the `sessionLength`, `breakLength` as expected. There is still an issue where user input is not consistently reflected.
